### PR TITLE
tls support (ipv4.icanhazip.com)

### DIFF
--- a/godaddy_ddns.py
+++ b/godaddy_ddns.py
@@ -83,7 +83,7 @@ def main():
 
   if not args.ip:
     try:
-      with urlopen("http://ipv4.icanhazip.com/") as f: resp=f.read()
+      with urlopen("https://ipv4.icanhazip.com/") as f: resp=f.read()
       if sys.version_info > (3,): resp = resp.decode('utf-8')
       args.ip = resp.strip()
     except URLError:


### PR DESCRIPTION
Currently, the call for ipv4.icanhazip.com does not use tls.  With this in mind, if someone is able to man in the middle the request the resulting ip address from the server could be tampered with.  If the host is invalid (since we are not verifying the host by the certificate presented), we do not know if someone has redirected the dynamic dns client to the legitimate ipv4.icanhazip.com server.  Please feel free to let me know if you have any further questions or concerns.